### PR TITLE
feat: options that are passed to onesignal api are now fully customizable

### DIFF
--- a/lib/arke_server/utils/onesignal.ex
+++ b/lib/arke_server/utils/onesignal.ex
@@ -33,6 +33,17 @@ defmodule ArkeServer.Utils.OneSignal do
     call_api(:post, "/apps/#{app_id}/users", data)
   end
 
+  @doc """
+  Creates a OneSignal push notification
+
+  ## Parameter
+    - member => single member or list of members
+    - contents => %{key: value} => see OneSignal api docs for `contents` push notification map key.
+    This has been kept for retrocompatibility, passing `contents` as a `custom_data` map key should now
+    be preferred
+    - custom_data => %{key: value} => see OneSignal api docs for push notifications. These are options for
+    the soon-to-be-created notification
+  """
   def create_notification(member, contents, custom_data \\ %{})
 
   def create_notification(member, contents, custom_data) when is_map(member),

--- a/lib/arke_server/utils/onesignal.ex
+++ b/lib/arke_server/utils/onesignal.ex
@@ -36,7 +36,7 @@ defmodule ArkeServer.Utils.OneSignal do
   def create_notification(member, contents) when is_map(member),
     do: create_notification([member], contents)
 
-  def create_notification(members, contents) when is_list(members) do
+  def create_notification(members, contents, custom_data \\ %{}) when is_list(members) do
     external_id = Enum.map(members, fn m -> to_string(m.id) end)
     app_id = System.get_env("ONESIGNAL_APP_ID")
 
@@ -47,7 +47,7 @@ defmodule ArkeServer.Utils.OneSignal do
       contents: contents
     }
 
-    call_api(:post, "/notifications", data)
+    call_api(:post, "/notifications", Map.merge(data, custom_data))
   end
 
   defp call_api(method, path, body, opts \\ []) do

--- a/lib/arke_server/utils/onesignal.ex
+++ b/lib/arke_server/utils/onesignal.ex
@@ -33,8 +33,8 @@ defmodule ArkeServer.Utils.OneSignal do
     call_api(:post, "/apps/#{app_id}/users", data)
   end
 
-  def create_notification(member, contents) when is_map(member),
-    do: create_notification([member], contents)
+  def create_notification(member, contents, custom_data \\ %{}) when is_map(member),
+    do: create_notification([member], contents, custom_data)
 
   def create_notification(members, contents, custom_data \\ %{}) when is_list(members) do
     external_id = Enum.map(members, fn m -> to_string(m.id) end)

--- a/lib/arke_server/utils/onesignal.ex
+++ b/lib/arke_server/utils/onesignal.ex
@@ -33,10 +33,12 @@ defmodule ArkeServer.Utils.OneSignal do
     call_api(:post, "/apps/#{app_id}/users", data)
   end
 
-  def create_notification(member, contents, custom_data \\ %{}) when is_map(member),
+  def create_notification(member, contents, custom_data \\ %{})
+
+  def create_notification(member, contents, custom_data) when is_map(member),
     do: create_notification([member], contents, custom_data)
 
-  def create_notification(members, contents, custom_data \\ %{}) when is_list(members) do
+  def create_notification(members, contents, custom_data) when is_list(members) do
     external_id = Enum.map(members, fn m -> to_string(m.id) end)
     app_id = System.get_env("ONESIGNAL_APP_ID")
 


### PR DESCRIPTION
## Description

Added new optional parameter to `create_notification`. This allows full control over OneSignal api options while maintaining retrocompatibility.