### PR TITLE
Drop unused Timex branch in Apple OAuth

### DIFF
--- a/lib/arke_server/oauth/providers/apple.ex
+++ b/lib/arke_server/oauth/providers/apple.ex
@@ -88,8 +88,7 @@
           true <- Map.get(decoded, "aud", nil) == app_id,
           true <- Map.get(decoded, "nonce", nil) == nonce,
           true <-
-            DatetimeHandler.from_unix(Map.get(decoded, "exp", 0)) > DatetimeHandler.now(:datetime) or
-              Timex.from_unix(Map.get(decoded, "exp", 0)) > DatetimeHandler.now(:datetime) do
+            DatetimeHandler.from_unix(Map.get(decoded, "exp", 0)) > DatetimeHandler.now(:datetime) do
        {:ok, decoded}
      else
        _ -> Error.create(:auth, "invalid token")


### PR DESCRIPTION
The expiry check in apple.ex has two operands joined by `or`:

```elixir
DatetimeHandler.from_unix(exp) > now or Timex.from_unix(exp) > now
```

Both sides compute the same value, so the `Timex` branch is dead code. Removing it.

This is also the only Timex reference left in arke-server, which otherwise only
pulled Timex transitively through arke. Safe to merge on its own; required once
arke drops Timex.