### PR TITLE
chore: format pass and lint CI leg

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  import_deps: [:phoenix],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             otp: "26.2.5"
           - elixir: "1.18.4"
             otp: "26.2.5"
+            lint: lint
     services:
       postgres:
         image: postgres
@@ -57,6 +58,9 @@ jobs:
         run: mix deps.get
       - name: Compile dependencies
         run: mix deps.compile
+      - name: Ensure files are formatted
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
       - name: Build package
         run: mix hex.build
       - name: Run tests

--- a/lib/arke_server.ex
+++ b/lib/arke_server.ex
@@ -14,21 +14,21 @@
 
 defmodule ArkeServer do
   @moduledoc """
-             The entrypoint for defining your web interface, such
-             as controllers, channels and so on.
+  The entrypoint for defining your web interface, such
+  as controllers, channels and so on.
 
-             This can be used in your application as:
+  This can be used in your application as:
 
-                 use ArkeServer, :controller
+      use ArkeServer, :controller
 
-             The definitions below will be executed for every
-             controller, etc, so keep them short and clean, focused
-             on imports, uses and aliases.
+  The definitions below will be executed for every
+  controller, etc, so keep them short and clean, focused
+  on imports, uses and aliases.
 
-             Do NOT define functions inside the quoted expressions
-             below. Instead, define any helper function in modules
-             and import those modules here.
-             """
+  Do NOT define functions inside the quoted expressions
+  below. Instead, define any helper function in modules
+  and import those modules here.
+  """
 
   def controller do
     quote do
@@ -59,7 +59,8 @@ defmodule ArkeServer do
     def status(%Arke.Errors.ArkeError{type: :not_found}), do: 404
     def status(%Arke.Errors.ArkeError{type: _type}), do: 400
 
-    def actions(_exception), do: []  end
+    def actions(_exception), do: []
+  end
 
   @doc """
   When used, dispatch to the appropriate controller/view/etc.

--- a/lib/arke_server/controllers/arke_controller.ex
+++ b/lib/arke_server/controllers/arke_controller.ex
@@ -26,7 +26,7 @@ defmodule ArkeServer.ArkeController do
   alias Arke.Boundary.ArkeManager
   alias UnitSerializer
   alias ArkeServer.ResponseManager
-  alias ArkeServer.Utils.{QueryFilters,QueryOrder, QueryProcessor,Permission}
+  alias ArkeServer.Utils.{QueryFilters, QueryOrder, QueryProcessor, Permission}
 
   alias ArkeServer.Openapi.Responses
 

--- a/lib/arke_server/controllers/health_controller.ex
+++ b/lib/arke_server/controllers/health_controller.ex
@@ -3,17 +3,17 @@ defmodule ArkeServer.HealthController do
   alias ArkeServer.ResponseManager
 
   # Endpoint useful for readiness probe
-  def ready(conn,_params) do
-    ResponseManager.send_resp(conn,200,nil)
+  def ready(conn, _params) do
+    ResponseManager.send_resp(conn, 200, nil)
   end
 
   # Endpoint useful for liveness probe
-  def live(conn,_params) do
-    ResponseManager.send_resp(conn,200,nil)
+  def live(conn, _params) do
+    ResponseManager.send_resp(conn, 200, nil)
   end
 
   # Endpoint useful for startup probe
-  def start(conn,_params) do
-    ResponseManager.send_resp(conn,200,nil)
+  def start(conn, _params) do
+    ResponseManager.send_resp(conn, 200, nil)
   end
 end

--- a/lib/arke_server/controllers/oauth_controller.ex
+++ b/lib/arke_server/controllers/oauth_controller.ex
@@ -23,7 +23,6 @@ defmodule ArkeServer.OAuthController do
   # Openapi request definition
   use ArkeServer.Openapi.Spec, module: ArkeServer.Openapi.OAuthControllerSpec
 
-
   alias Arke.Boundary.GroupManager
 
   alias ArkeServer.ResponseManager
@@ -49,13 +48,18 @@ defmodule ArkeServer.OAuthController do
         _params
       ) do
     project = conn.assigns[:arke_project]
-    case init_oauth_flow(project,auth, provider) do
-      {:ok, body,oauth_member} ->
+
+    case init_oauth_flow(project, auth, provider) do
+      {:ok, body, oauth_member} ->
         member = QueryManager.get_by(project: project, id: oauth_member.id)
-        handle_member_login(conn,member)
+        handle_member_login(conn, member)
         ResponseManager.send_resp(conn, 200, %{content: body})
-      {:error,[%{context: "auth", message: "unauthorized"}]=msg} -> ResponseManager.send_resp(conn, 401, msg)
-      {:error, msg} -> ResponseManager.send_resp(conn, 400, msg)
+
+      {:error, [%{context: "auth", message: "unauthorized"}] = msg} ->
+        ResponseManager.send_resp(conn, 401, msg)
+
+      {:error, msg} ->
+        ResponseManager.send_resp(conn, 400, msg)
     end
   end
 
@@ -72,56 +76,81 @@ defmodule ArkeServer.OAuthController do
   end
 
   def handle_create_member(
-    %Plug.Conn{body_params: params}=conn,
-        %{"member" => member_id, "provider" => provider}=_all_params
+        %Plug.Conn{body_params: params} = conn,
+        %{"member" => member_id, "provider" => provider} = _all_params
       ) do
     user_resource = ArkeAuth.SSOGuardian.Plug.current_resource(conn)
-    user = QueryManager.get_by(project: :arke_system, arke_id: :user,id: user_resource.id)
+    user = QueryManager.get_by(project: :arke_system, arke_id: :user, id: user_resource.id)
     project = conn.assigns[:arke_project]
     provider_arke_id = String.to_existing_atom("oauth_#{provider}")
-    enable_sso_group = GroupManager.get(:enable_sso,project)
+    enable_sso_group = GroupManager.get(:enable_sso, project)
     # check if the given member_id is enable to sso login
     # check if the user has any oauth link
     # check if one of the oauth link has the arke_id equal to the given provider
-    with true <- member_id in (GroupManager.get_arke_list(enable_sso_group) |> Enum.map(fn ak -> to_string(ak.id)end)),
-         [_data] = link_list <- get_link(user,:child),
-         %Unit{}=_unit <- Enum.find(link_list, fn link_unit -> link_unit.arke_id == provider_arke_id end) do
-      case check_member(project,user) do
+    # there are no units associated with that provider or the provider does not exist
+    with true <-
+           member_id in (GroupManager.get_arke_list(enable_sso_group)
+                         |> Enum.map(fn ak -> to_string(ak.id) end)),
+         [_data] = link_list <- get_link(user, :child),
+         %Unit{} = _unit <-
+           Enum.find(link_list, fn link_unit -> link_unit.arke_id == provider_arke_id end) do
+      case check_member(project, user) do
         # member does not exists so create one
-        {:ok,nil} ->
-        case create_member(project,user,params,member_id) do
-          {:ok,member} ->
-            {:ok, resource_member, access_token, refresh_token} = Auth.create_tokens(member,"default")
-            content = create_response_body(resource_member,access_token,refresh_token,false)
-            AuthController.mailer_module().signup(conn,resource_member, mode: "oauth",member: resource_member,response_body: content)
-            ResponseManager.send_resp(conn, 200, content)
-          err -> ResponseManager.send_resp(conn, 400, err)
-        end
+        {:ok, nil} ->
+          case create_member(project, user, params, member_id) do
+            {:ok, member} ->
+              {:ok, resource_member, access_token, refresh_token} =
+                Auth.create_tokens(member, "default")
+
+              content = create_response_body(resource_member, access_token, refresh_token, false)
+
+              AuthController.mailer_module().signup(conn, resource_member,
+                mode: "oauth",
+                member: resource_member,
+                response_body: content
+              )
+
+              ResponseManager.send_resp(conn, 200, content)
+
+            err ->
+              ResponseManager.send_resp(conn, 400, err)
+          end
+
         # member exists and it is active
         {:ok, resource_member, access_token, refresh_token} ->
-          content = create_response_body(resource_member,access_token,refresh_token,false)
-          AuthController.mailer_module().signup(conn,resource_member, mode: "oauth",member: resource_member,response_body: content)
+          content = create_response_body(resource_member, access_token, refresh_token, false)
+
+          AuthController.mailer_module().signup(conn, resource_member,
+            mode: "oauth",
+            member: resource_member,
+            response_body: content
+          )
+
           ResponseManager.send_resp(conn, 200, content)
+
         {:error, reason} ->
           {:error, reason}
       end
-      else nil -> # there are no units associated with that provider or the provider does not exist
-            # in any of the unit sso associated with the user
+    else
+      nil ->
+        # in any of the unit sso associated with the user
         {:error, msg} = Error.create(:sso, "invalid provider")
         ResponseManager.send_resp(conn, 400, msg)
-      false -> {:error, msg} = Error.create(:sso, "invalid member")
-               ResponseManager.send_resp(conn, 400, msg) # sso not enabled for the given member
+
+      false ->
+        {:error, msg} = Error.create(:sso, "invalid member")
+        # sso not enabled for the given member
+        ResponseManager.send_resp(conn, 400, msg)
     end
   end
 
   def handle_create_member(
-         conn,
+        conn,
         _params
       ) do
     {:error, msg} = Error.create(:auth, "invalid token/provider")
     ResponseManager.send_resp(conn, 400, msg)
   end
-
 
   # ------- Client Side -------
 
@@ -135,31 +164,36 @@ defmodule ArkeServer.OAuthController do
         _params
       ) do
     project = conn.assigns[:arke_project]
-    case init_oauth_flow(project,auth, provider) do
-      {:ok, body,_member} ->
+
+    case init_oauth_flow(project, auth, provider) do
+      {:ok, body, _member} ->
         ResponseManager.send_resp(conn, 200, %{content: body})
-      {:error, msg} -> ResponseManager.send_resp(conn, 400, msg)
+
+      {:error, msg} ->
+        ResponseManager.send_resp(conn, 400, msg)
     end
   end
 
   # ------- end Using redirects -------
 
-  defp init_oauth_flow(project,auth_info, provider) do
+  defp init_oauth_flow(project, auth_info, provider) do
     with {:ok, nil} <- check_provider(provider),
          {:ok, user} <- check_oauth(auth_info) do
-         case check_member(project,user) do
-           #if member does not exists creat a SSO token
-            {:ok,nil} -> {:ok, user, access_token, refresh_token} = Auth.create_tokens(user,"sso")
-                content = create_response_body(user,access_token,refresh_token,true)
-                {:ok, content,user}
-                # if exists and is active authenticate the user
-            {:ok, resource_member, access_token, refresh_token} ->
+      case check_member(project, user) do
+        # if member does not exists creat a SSO token
+        {:ok, nil} ->
+          {:ok, user, access_token, refresh_token} = Auth.create_tokens(user, "sso")
+          content = create_response_body(user, access_token, refresh_token, true)
+          {:ok, content, user}
 
-              content = create_response_body(resource_member,access_token,refresh_token,false)
-              {:ok, content,resource_member}
-           {:error, reason} ->
-             {:error, reason}
-         end
+        # if exists and is active authenticate the user
+        {:ok, resource_member, access_token, refresh_token} ->
+          content = create_response_body(resource_member, access_token, refresh_token, false)
+          {:ok, content, resource_member}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     else
       {:error, reason} ->
         {:error, reason}
@@ -200,31 +234,34 @@ defmodule ArkeServer.OAuthController do
     check_oauth_user(oauth_user_data, provider)
   end
 
-  defp create_response_body(resource,access_token,refresh_token,uncompleted_data) do
+  defp create_response_body(resource, access_token, refresh_token, uncompleted_data) do
     Map.merge(Arke.StructManager.encode(resource, type: :json), %{
       access_token: access_token,
       refresh_token: refresh_token,
-      uncompleted_data: uncompleted_data,
+      uncompleted_data: uncompleted_data
     })
   end
 
-  defp create_member(project,user,params,member_id) do
-    member_model = ArkeManager.get(String.to_atom(member_id),project)
-    member_data = Map.put(params,"arke_system_user", to_string(user.id)) |> Map.put("email",user.data.email)
+  defp create_member(project, user, params, member_id) do
+    member_model = ArkeManager.get(String.to_atom(member_id), project)
+
+    member_data =
+      Map.put(params, "arke_system_user", to_string(user.id)) |> Map.put("email", user.data.email)
+
     new_data = for {key, val} <- member_data, into: %{}, do: {String.to_atom(key), val}
-    QueryManager.create(project,member_model,new_data)
+    QueryManager.create(project, member_model, new_data)
   end
 
   defp create_user(user_data) do
     user_model = ArkeManager.get(:user, :arke_system)
     pwd = UUID.uuid4()
     updated_data = Map.put(user_data, :password, pwd)
-    email = Map.get(user_data,:email)
+    email = Map.get(user_data, :email)
+
     case QueryManager.get_by(project: :arke_system, arke_id: :user, email: email) do
       nil -> QueryManager.create(:arke_system, user_model, updated_data)
-      user -> {:ok,user}
+      user -> {:ok, user}
     end
-
   end
 
   defp create_link(parent_id, child_id, provider) do
@@ -233,13 +270,13 @@ defmodule ArkeServer.OAuthController do
     })
   end
 
-  defp get_link(unit,direction) do
+  defp get_link(unit, direction) do
     QueryManager.query(project: :arke_system)
     |> QueryManager.link(unit,
-         depth: 1,
-         direction: direction,
-         type: "oauth"
-       )
+      depth: 1,
+      direction: direction,
+      type: "oauth"
+    )
     |> QueryManager.all()
   end
 
@@ -269,7 +306,7 @@ defmodule ArkeServer.OAuthController do
 
       oauth_unit ->
         # check if there is a link between the given oauth_unit and an user
-        case get_link(oauth_unit,:parent) do
+        case get_link(oauth_unit, :parent) do
           [] ->
             # create a user and connect the two
             with {:ok, user} <- create_user(oauth_user_data),
@@ -290,17 +327,19 @@ defmodule ArkeServer.OAuthController do
     end
   end
 
-  defp check_member(project,user) do
-    case Auth.get_project_member(project,user) do
-      {:ok , member} -> Auth.create_tokens(Auth.format_member(member),"default")
-      {:error, [%{context: "auth", message: "member not exists"}]} -> {:ok,nil} # if not exists return {:ok,nil}
-      {:error, _msg} ->  Error.create(:auth, "unauthorized")
+  defp check_member(project, user) do
+    case Auth.get_project_member(project, user) do
+      {:ok, member} -> Auth.create_tokens(Auth.format_member(member), "default")
+      # if not exists return {:ok,nil}
+      {:error, [%{context: "auth", message: "member not exists"}]} -> {:ok, nil}
+      {:error, _msg} -> Error.create(:auth, "unauthorized")
     end
   end
 
-  defp handle_member_login(_conn,nil), do: nil
-  defp handle_member_login(conn,member) do
+  defp handle_member_login(_conn, nil), do: nil
+
+  defp handle_member_login(conn, member) do
     AuthController.update_member_access_time(member)
-    AuthController.mailer_module().signin(conn,member, mode: "oauth")
+    AuthController.mailer_module().signin(conn, member, mode: "oauth")
   end
 end

--- a/lib/arke_server/controllers/parameter_controller.ex
+++ b/lib/arke_server/controllers/parameter_controller.ex
@@ -18,14 +18,13 @@ defmodule ArkeServer.ParameterController do
   # Openapi request definition
   use ArkeServer.Openapi.Spec, module: ArkeServer.Openapi.ParameterControllerSpec
 
-
   alias Arke.Boundary.ParameterManager
   alias ArkeServer.ResponseManager
   alias Arke.StructManager
 
   @doc """
-       Get parameter value
-       """
+  Get parameter value
+  """
   def get_parameter_value(conn, %{"parameter" => parameter_id}) do
     project = conn.assigns[:arke_project]
     unit = conn.assigns[:unit]
@@ -50,7 +49,8 @@ defmodule ArkeServer.ParameterController do
 
     ResponseManager.send_resp(conn, 200, %{
       count: count,
-      items: StructManager.encode(units, load_links: load_links, load_values: load_values, type: :json)
+      items:
+        StructManager.encode(units, load_links: load_links, load_values: load_values, type: :json)
     })
   end
 

--- a/lib/arke_server/controllers/project_controller.ex
+++ b/lib/arke_server/controllers/project_controller.ex
@@ -22,7 +22,6 @@ defmodule ArkeServer.ProjectController do
   # Openapi request definition
   use ArkeServer.Openapi.Spec, module: ArkeServer.Openapi.ProjectControllerSpec
 
-
   alias Arke.{QueryManager, LinkManager, StructManager}
   alias Arke.Boundary.ArkeManager
   alias UnitSerializer
@@ -33,8 +32,8 @@ defmodule ArkeServer.ProjectController do
   end
 
   @doc """
-       Create a new unit
-       """
+  Create a new unit
+  """
   def create(conn, params) do
     # all arkes struct and gen server are on :arke_system so it won't be changed to project
     arke = ArkeManager.get(:arke_project, :arke_system)
@@ -50,8 +49,8 @@ defmodule ArkeServer.ProjectController do
   end
 
   @doc """
-       Update an unit
-       """
+  Update an unit
+  """
   def update(%Plug.Conn{body_params: params} = conn, %{"unit_id" => unit_id}) do
     arke = ArkeManager.get(:arke_project, :arke_system)
     unit = QueryManager.get_by(project: :arke_system, arke: arke, id: unit_id)
@@ -68,8 +67,8 @@ defmodule ArkeServer.ProjectController do
 
   # delete
   @doc """
-       Delete a unit
-       """
+  Delete a unit
+  """
   def delete(conn, %{"unit_id" => unit_id}) do
     arke = ArkeManager.get(:arke_project, :arke_system)
     unit = QueryManager.get_by(project: :arke_system, arke: arke, id: unit_id)
@@ -82,16 +81,16 @@ defmodule ArkeServer.ProjectController do
   end
 
   @doc """
-       Get a units of arke_project
-       """
+  Get a units of arke_project
+  """
   def get_all_unit(conn, %{}) do
     arke_list = QueryManager.filter_by(project: :arke_system, arke: :arke_project)
     ResponseManager.send_resp(conn, 200, %{items: StructManager.encode(arke_list, type: :json)})
   end
 
   @doc """
-       It returns a unit
-       """
+  It returns a unit
+  """
   def get_unit(conn, %{"unit_id" => unit_id}) do
     arke = ArkeManager.get(:arke_project, :arke_system)
     unit = QueryManager.get_by(project: :arke_system, arke: arke, id: unit_id)

--- a/lib/arke_server/controllers/struct_controller.ex
+++ b/lib/arke_server/controllers/struct_controller.ex
@@ -14,13 +14,12 @@
 
 defmodule ArkeServer.StructController do
   @moduledoc """
-              Documentation for`ArkeServer.StructController
-             """
+   Documentation for`ArkeServer.StructController
+  """
   use ArkeServer, :controller
 
   # Openapi request definition
   use ArkeServer.Openapi.Spec, module: ArkeServer.Openapi.StructControllerSpec
-
 
   alias Arke.{StructManager}
   alias Arke.Boundary.ArkeManager
@@ -31,20 +30,21 @@ defmodule ArkeServer.StructController do
   alias OpenApiSpex.{Operation, Reference}
 
   @doc """
-       Get a struct of a unit
-       """
+  Get a struct of a unit
+  """
   def get_unit_struct(conn, %{"arke_id" => arke_id, "arke_unit_id" => _id}) do
     project = conn.assigns[:arke_project]
     arke = ArkeManager.get(String.to_existing_atom(arke_id), project)
     arke = Arke.Core.Unit.update(arke, runtime_data: %{conn: conn})
+
     ResponseManager.send_resp(conn, 200, %{
       content: StructManager.get_struct(arke, conn.assigns[:unit], conn.query_params)
     })
   end
 
   @doc """
-       Get a struct of an Arke
-       """
+  Get a struct of an Arke
+  """
   def get_arke_struct(conn, %{"arke_id" => id}) do
     project = conn.assigns[:arke_project]
 

--- a/lib/arke_server/controllers/unit_controller.ex
+++ b/lib/arke_server/controllers/unit_controller.ex
@@ -18,7 +18,6 @@ defmodule ArkeServer.UnitController do
   # Openapi request definition
   use ArkeServer.Openapi.Spec, module: ArkeServer.Openapi.UnitControllerSpec
 
-
   alias Arke.{QueryManager, LinkManager, StructManager}
   alias Arke.Boundary.{ArkeManager, ParameterManager}
   alias UnitSerializer
@@ -31,8 +30,8 @@ defmodule ArkeServer.UnitController do
   import ArkeServer.ArkeController, only: [data_as_klist: 1]
 
   @doc """
-       Search units
-       """
+  Search units
+  """
   def search(conn, %{}) do
     project = conn.assigns[:arke_project]
     limit = Map.get(conn.query_params, "limit", 100)
@@ -49,8 +48,8 @@ defmodule ArkeServer.UnitController do
   end
 
   @doc """
-       Update an unit
-       """
+  Update an unit
+  """
   def update(%Plug.Conn{body_params: params} = conn, %{
         "unit_id" => _unit_id,
         "arke_id" => _arke_id

--- a/lib/arke_server/email_manager/mailer.ex
+++ b/lib/arke_server/email_manager/mailer.ex
@@ -1,13 +1,12 @@
 defmodule ArkeServer.Mailer do
-
-  defmacro __using__(_)do
+  defmacro __using__(_) do
     quote do
       use Swoosh.Mailer, otp_app: :arke_server
       import Swoosh.Email
 
-      def signin(conn,member,opts), do: {:ok,opts}
-      def signup(conn,params,opts), do: {:ok,opts}
-      def reset_password(conn,member,opts), do: {:ok,opts}
+      def signin(conn, member, opts), do: {:ok, opts}
+      def signup(conn, params, opts), do: {:ok, opts}
+      def reset_password(conn, member, opts), do: {:ok, opts}
 
       def send_email(opts) when is_list(opts) do
         case Keyword.keyword?(opts) do
@@ -32,6 +31,7 @@ defmodule ArkeServer.Mailer do
         text = Map.get(opts, :text, "")
         html = Map.get(opts, :html, "")
         attachments = Map.get(opts, :attachments, [])
+
         new()
         |> from(sender)
         |> to(receiver)
@@ -47,7 +47,7 @@ defmodule ArkeServer.Mailer do
       defp get_sender(opts) do
         case Map.get(opts, :from, nil) do
           nil ->
-            case Application.get_env(:arke_server,__MODULE__)[:default_sender] do
+            case Application.get_env(:arke_server, __MODULE__)[:default_sender] do
               nil -> raise "missing `from:` value and `default_sender` is not set"
               default_sender -> default_sender
             end
@@ -63,7 +63,7 @@ defmodule ArkeServer.Mailer do
       end
 
       defp parse_option(email, [{k, v} | t])
-           when  not is_nil(v) do
+           when not is_nil(v) do
         parse_option(put_provider_option(email, k, v), t)
       end
 
@@ -72,8 +72,7 @@ defmodule ArkeServer.Mailer do
       defp parse_option(email, nil), do: email
       defp parse_option(email, []), do: email
 
-      defoverridable signin: 3,signup: 3, reset_password: 3,send_email: 1
+      defoverridable signin: 3, signup: 3, reset_password: 3, send_email: 1
     end
-
   end
 end

--- a/lib/arke_server/email_manager/mailtrap.ex
+++ b/lib/arke_server/email_manager/mailtrap.ex
@@ -3,7 +3,7 @@ defmodule ArkeServer.Swoosh.Adapters.Mailtrap do
     :custom_variables,
     :category,
     :template_uuid,
-    :template_variables,
+    :template_variables
   ]
 
   @moduledoc ~s"""
@@ -88,7 +88,7 @@ defmodule ArkeServer.Swoosh.Adapters.Mailtrap do
 
     body = email |> prepare_body() |> Swoosh.json_library().encode!
     url = prepare_url(config)
-#    IO.inspect({url, headers, body, email})
+    #    IO.inspect({url, headers, body, email})
     case Swoosh.ApiClient.post(url, headers, body, email) do
       {:ok, code, _headers, body} when code >= 200 and code <= 399 ->
         {:ok, %{ids: Swoosh.json_library().decode!(body)["message_ids"]}}
@@ -114,7 +114,7 @@ defmodule ArkeServer.Swoosh.Adapters.Mailtrap do
   end
 
   defp base_url(config),
-       do: config[:base_url] || @base_url
+    do: config[:base_url] || @base_url
 
   defp prepare_body(email) do
     %{}
@@ -139,33 +139,33 @@ defmodule ArkeServer.Swoosh.Adapters.Mailtrap do
   defp reply_to_item(email), do: email
 
   defp prepare_from(body, %{from: from}),
-       do: Map.put(body, :from, from |> email_item)
+    do: Map.put(body, :from, from |> email_item)
 
   defp prepare_to(body, %{to: to}),
-       do: Map.put(body, :to, to |> Enum.map(&email_item(&1)))
+    do: Map.put(body, :to, to |> Enum.map(&email_item(&1)))
 
   defp prepare_cc(body, %{cc: []}), do: body
 
   defp prepare_cc(body, %{cc: cc}),
-       do: Map.put(body, :cc, cc |> Enum.map(&email_item(&1)))
+    do: Map.put(body, :cc, cc |> Enum.map(&email_item(&1)))
 
   defp prepare_bcc(body, %{bcc: []}), do: body
 
   defp prepare_bcc(body, %{bcc: bcc}),
-       do: Map.put(body, :bcc, bcc |> Enum.map(&email_item(&1)))
+    do: Map.put(body, :bcc, bcc |> Enum.map(&email_item(&1)))
 
   defp prepare_subject(body, %{subject: subject}),
-       do: Map.put(body, :subject, subject)
+    do: Map.put(body, :subject, subject)
 
   defp prepare_text(body, %{text_body: nil}), do: body
 
   defp prepare_text(body, %{text_body: text}),
-       do: Map.put(body, :text, text)
+    do: Map.put(body, :text, text)
 
   defp prepare_html(body, %{html_body: nil}), do: body
 
   defp prepare_html(body, %{html_body: html}),
-       do: Map.put(body, :html, html)
+    do: Map.put(body, :html, html)
 
   defp prepare_attachments(body, %{attachments: []}), do: body
 
@@ -205,7 +205,7 @@ defmodule ArkeServer.Swoosh.Adapters.Mailtrap do
   end
 
   defp prepare_custom_headers(body, %{headers: headers}),
-       do: Map.put(body, :headers, headers)
+    do: Map.put(body, :headers, headers)
 
   defp prepare_provider_options_body_fields(body, %{provider_options: provider_options}) do
     Map.merge(body, Map.take(provider_options, @provider_options_body_fields))

--- a/lib/arke_server/email_manager/one_signal_adapter.ex
+++ b/lib/arke_server/email_manager/one_signal_adapter.ex
@@ -63,7 +63,9 @@ defmodule ArkeServer.Swoosh.Adapters.OneSignal do
   Mailgun recognizes.
   """
 
-  use Swoosh.Adapter, required_config: [:api_key, :domain, :app_id], required_deps: [plug: Plug.Conn.Query]
+  use Swoosh.Adapter,
+    required_config: [:api_key, :domain, :app_id],
+    required_deps: [plug: Plug.Conn.Query]
 
   alias Swoosh.Email
   import Swoosh.Email.Render
@@ -125,18 +127,17 @@ defmodule ArkeServer.Swoosh.Adapters.OneSignal do
     |> encode_body()
   end
 
-
-#  defp prepare_custom_vars(body, %{provider_options: %{custom_vars: custom_vars}}) do
-#    Map.put(body, "h:X-Mailgun-Variables", Swoosh.json_library().encode!(custom_vars))
-#  end
+  #  defp prepare_custom_vars(body, %{provider_options: %{custom_vars: custom_vars}}) do
+  #    Map.put(body, "h:X-Mailgun-Variables", Swoosh.json_library().encode!(custom_vars))
+  #  end
 
   defp prepare_custom_vars(body, _email), do: body
 
-#  defp prepare_sending_options(body, %{provider_options: %{sending_options: sending_options}}) do
-#    Enum.reduce(sending_options, body, fn {k, v}, body ->
-#      Map.put(body, "o:#{k}", encode_variable(v))
-#    end)
-#  end
+  #  defp prepare_sending_options(body, %{provider_options: %{sending_options: sending_options}}) do
+  #    Enum.reduce(sending_options, body, fn {k, v}, body ->
+  #      Map.put(body, "o:#{k}", encode_variable(v))
+  #    end)
+  #  end
 
   defp prepare_sending_options(body, _email), do: body
 
@@ -178,7 +179,8 @@ defmodule ArkeServer.Swoosh.Adapters.OneSignal do
      [{"Content-Type", attachment.content_type}]}
   end
 
-  defp prepare_from(body, %{from: from}), do: Map.put(body, :email_from_address, render_recipient(from))
+  defp prepare_from(body, %{from: from}),
+    do: Map.put(body, :email_from_address, render_recipient(from))
 
   defp prepare_to(body, %{to: to}), do: Map.put(body, :to, render_recipient(to))
 

--- a/lib/arke_server/endpoint.ex
+++ b/lib/arke_server/endpoint.ex
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 defmodule ArkeServer.Endpoint do
-
   @moduledoc """
-             Module which define the Plug used for each call
-             """
+  Module which define the Plug used for each call
+  """
   use Phoenix.Endpoint, otp_app: :arke_server
 
   # The session will be stored in the cookie and signed,

--- a/lib/arke_server/error_handlers/auth_error_handler.ex
+++ b/lib/arke_server/error_handlers/auth_error_handler.ex
@@ -17,7 +17,7 @@
 ########################################################################
 defmodule ArkeServer.ErrorHandlers.Auth do
   @moduledoc """
-             """
+  """
 
   alias Arke.Utils.ErrorGenerator, as: Error
   import Plug.Conn
@@ -37,12 +37,13 @@ defmodule ArkeServer.ErrorHandlers.Auth do
     end
   end
 end
+
 ########################################################################
 ### SSO AUTH PIPELINE ##################################################
 ########################################################################
 defmodule ArkeServer.ErrorHandlers.SSOAuth do
   @moduledoc """
-             """
+  """
 
   alias Arke.Utils.ErrorGenerator, as: Error
   import Plug.Conn

--- a/lib/arke_server/oauth/providers/apple.ex
+++ b/lib/arke_server/oauth/providers/apple.ex
@@ -1,95 +1,95 @@
- defmodule ArkeServer.OAuth.Provider.Apple do
-   use ArkeServer.OAuth.Core
-   alias Arke.Utils.DatetimeHandler, as: DatetimeHandler
-   @private_oauth_key :arke_server_oauth
+defmodule ArkeServer.OAuth.Provider.Apple do
+  use ArkeServer.OAuth.Core
+  alias Arke.Utils.DatetimeHandler, as: DatetimeHandler
+  @private_oauth_key :arke_server_oauth
 
-   def info(conn) do
-     token_data = conn.private[@private_oauth_key]
+  def info(conn) do
+    token_data = conn.private[@private_oauth_key]
 
-     %UserInfo{
-       first_name: token_data["given_name"],
-       last_name: token_data["family_name"],
-       email: token_data["email"]
-     }
-   end
+    %UserInfo{
+      first_name: token_data["given_name"],
+      last_name: token_data["family_name"],
+      email: token_data["email"]
+    }
+  end
 
-   def uid(conn) do
-     conn.private[@private_oauth_key]["sub"]
-   end
+  def uid(conn) do
+    conn.private[@private_oauth_key]["sub"]
+  end
 
-   def handle_cleanup(conn), do: put_private(conn, @private_oauth_key, nil)
+  def handle_cleanup(conn), do: put_private(conn, @private_oauth_key, nil)
 
-   # verify the token validity based on: https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user
-   def handle_request(%Plug.Conn{query_params: %{"token" => token, "nonce" => nonce}} = conn) do
-     try do
-       header = JOSE.JWT.peek_protected(token).fields
+  # verify the token validity based on: https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user
+  def handle_request(%Plug.Conn{query_params: %{"token" => token, "nonce" => nonce}} = conn) do
+    try do
+      header = JOSE.JWT.peek_protected(token).fields
 
-       with {:ok, jwk} <- get_public_key(header),
-            {true, %JOSE.JWT{} = jwt, _jws} <- JOSE.JWT.verify(jwk, token),
-            {:ok, data} <- validate_jwt(jwt, nonce) do
-         put_private(conn, @private_oauth_key, data)
-       else
-         {:error, msg} ->
-           Plug.Conn.assign(
-             conn,
-             :arke_server_oauth_failure,
-             msg
-           )
-       end
-     rescue
-       _ ->
-         Plug.Conn.assign(
-           conn,
-           :arke_server_oauth_failure,
-           Error.create(:auth, "invalid token")
-         )
-     end
-   end
+      with {:ok, jwk} <- get_public_key(header),
+           {true, %JOSE.JWT{} = jwt, _jws} <- JOSE.JWT.verify(jwk, token),
+           {:ok, data} <- validate_jwt(jwt, nonce) do
+        put_private(conn, @private_oauth_key, data)
+      else
+        {:error, msg} ->
+          Plug.Conn.assign(
+            conn,
+            :arke_server_oauth_failure,
+            msg
+          )
+      end
+    rescue
+      _ ->
+        Plug.Conn.assign(
+          conn,
+          :arke_server_oauth_failure,
+          Error.create(:auth, "invalid token")
+        )
+    end
+  end
 
-   def handle_request(conn) do
-     {:error, msg} = Error.create(:auth, "token/nonce not found")
+  def handle_request(conn) do
+    {:error, msg} = Error.create(:auth, "token/nonce not found")
 
-     Plug.Conn.assign(
-       conn,
-       :arke_server_oauth_failure,
-       msg
-     )
-   end
+    Plug.Conn.assign(
+      conn,
+      :arke_server_oauth_failure,
+      msg
+    )
+  end
 
-   defp get_public_key(%{"kid" => certificate_id}) do
-     # get pem certs to validate the token later
-     case Req.get("https://appleid.apple.com/auth/keys", retry: false) do
-       {:ok, %{status: 200, body: body}} ->
-         case Enum.find(body["keys"], nil, fn key -> key["kid"] == certificate_id end) do
-           nil ->
-             Error.create(:auth, "invalid token")
+  defp get_public_key(%{"kid" => certificate_id}) do
+    # get pem certs to validate the token later
+    case Req.get("https://appleid.apple.com/auth/keys", retry: false) do
+      {:ok, %{status: 200, body: body}} ->
+        case Enum.find(body["keys"], nil, fn key -> key["kid"] == certificate_id end) do
+          nil ->
+            Error.create(:auth, "invalid token")
 
-           key_cert ->
-             {:ok, JOSE.JWK.from_map(key_cert)}
-         end
+          key_cert ->
+            {:ok, JOSE.JWK.from_map(key_cert)}
+        end
 
-       _ ->
-         Error.create(:auth, "invalid token")
-     end
-   end
+      _ ->
+        Error.create(:auth, "invalid token")
+    end
+  end
 
-   defp get_public_key(token) do
-     Error.create(:auth, "invalid token")
-   end
+  defp get_public_key(token) do
+    Error.create(:auth, "invalid token")
+  end
 
-   defp validate_jwt(token, nonce) do
-     decoded = token.fields
-     app_id = System.get_env("APPLE_CLIENT_ID", nil)
+  defp validate_jwt(token, nonce) do
+    decoded = token.fields
+    app_id = System.get_env("APPLE_CLIENT_ID", nil)
 
-     with true <-
-            String.contains?(Map.get(decoded, "iss", ""), "https://appleid.apple.com"),
-          true <- Map.get(decoded, "aud", nil) == app_id,
-          true <- Map.get(decoded, "nonce", nil) == nonce,
-          true <-
-            DatetimeHandler.from_unix(Map.get(decoded, "exp", 0)) > DatetimeHandler.now(:datetime) do
-       {:ok, decoded}
-     else
-       _ -> Error.create(:auth, "invalid token")
-     end
-   end
- end
+    with true <-
+           String.contains?(Map.get(decoded, "iss", ""), "https://appleid.apple.com"),
+         true <- Map.get(decoded, "aud", nil) == app_id,
+         true <- Map.get(decoded, "nonce", nil) == nonce,
+         true <-
+           DatetimeHandler.from_unix(Map.get(decoded, "exp", 0)) > DatetimeHandler.now(:datetime) do
+      {:ok, decoded}
+    else
+      _ -> Error.create(:auth, "invalid token")
+    end
+  end
+end

--- a/lib/arke_server/oauth/providers/google.ex
+++ b/lib/arke_server/oauth/providers/google.ex
@@ -21,7 +21,7 @@ defmodule ArkeServer.OAuth.Provider.Google do
 
   def handle_cleanup(conn), do: put_private(conn, @private_oauth_key, nil)
 
-  def handle_request(%Plug.Conn{body_params: %{"account" => %{"id_token"=>token}}} = conn) do
+  def handle_request(%Plug.Conn{body_params: %{"account" => %{"id_token" => token}}} = conn) do
     try do
       header = JOSE.JWT.peek_protected(token).fields
 
@@ -49,6 +49,7 @@ defmodule ArkeServer.OAuth.Provider.Google do
 
   def handle_request(conn) do
     {:error, msg} = Error.create(:auth, "token not found")
+
     Plug.Conn.assign(
       conn,
       :arke_server_oauth_failure,

--- a/lib/arke_server/oauth/providers/microsoft.ex
+++ b/lib/arke_server/oauth/providers/microsoft.ex
@@ -13,7 +13,6 @@ defmodule ArkeServer.OAuth.Provider.Microsoft do
       last_name: token_data["surname"],
       email: token_data["mail"]
     }
-
   end
 
   def uid(conn) do
@@ -22,8 +21,9 @@ defmodule ArkeServer.OAuth.Provider.Microsoft do
 
   def handle_cleanup(conn), do: put_private(conn, @private_oauth_key, nil)
 
-
-  def handle_request(%Plug.Conn{body_params: %{"id_token" => token, "access_token"=> access_token}} = conn) do
+  def handle_request(
+        %Plug.Conn{body_params: %{"id_token" => token, "access_token" => access_token}} = conn
+      ) do
     with {:ok, claims} <- verify_token(token),
          {:ok, data} <- get_user_data(access_token) do
       put_private(conn, @private_oauth_key, data)
@@ -39,6 +39,7 @@ defmodule ArkeServer.OAuth.Provider.Microsoft do
 
   def handle_request(conn) do
     {:error, msg} = Error.create(:auth, "token not found")
+
     Plug.Conn.assign(
       conn,
       :arke_server_oauth_failure,
@@ -73,11 +74,11 @@ defmodule ArkeServer.OAuth.Provider.Microsoft do
 
   defp decode_and_verify(token) do
     jwt = JOSE.JWT.peek(token)
+
     case validate_signature(token) do
       :ok -> {:ok, jwt.fields}
       {:error, reason} -> {:error, reason}
     end
-
   end
 
   defp validate_signature(jwt) do
@@ -89,26 +90,36 @@ defmodule ArkeServer.OAuth.Provider.Microsoft do
           end
         end)
 
-      {:error, reason} -> {:error, reason}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
   defp get_public_keys do
     uri = "https://login.microsoftonline.com/#{get_key("AZURE_TENANT_ID")}/discovery/v2.0/keys"
+
     case Req.get(uri, retry: false) do
       {:ok, %{status: 200, body: body}} ->
         {:ok, body |> Map.get("keys") |> Enum.map(&JOSE.JWK.from(&1))}
 
-      {:error, exception} -> {:error, Exception.message(exception)}
+      {:error, exception} ->
+        {:error, Exception.message(exception)}
     end
   end
 
   defp validate_claims(claims) do
     cond do
-      claims["iss"] != "https://login.microsoftonline.com/#{get_key("AZURE_TENANT_ID")}/v2.0" -> {:error, "Invalid issuer"}
-      claims["tid"] != get_key("AZURE_TENANT_ID") -> {:error, "Invalid tenant"}
-      DatetimeHandler.from_unix(Map.get(claims, "exp", 0)) < DatetimeHandler.now(:datetime) -> {:error, "Token expired"}
-      true -> :ok
+      claims["iss"] != "https://login.microsoftonline.com/#{get_key("AZURE_TENANT_ID")}/v2.0" ->
+        {:error, "Invalid issuer"}
+
+      claims["tid"] != get_key("AZURE_TENANT_ID") ->
+        {:error, "Invalid tenant"}
+
+      DatetimeHandler.from_unix(Map.get(claims, "exp", 0)) < DatetimeHandler.now(:datetime) ->
+        {:error, "Token expired"}
+
+      true ->
+        :ok
     end
   end
 

--- a/lib/arke_server/openapi/arke_controller_spec.ex
+++ b/lib/arke_server/openapi/arke_controller_spec.ex
@@ -14,12 +14,11 @@
 
 defmodule ArkeServer.Openapi.ArkeControllerSpec do
   @moduledoc """
-             Definition of the ApiSpec for `ArkeServer.ArkeController`.
-             """
+  Definition of the ApiSpec for `ArkeServer.ArkeController`.
+  """
 
   alias ArkeServer.Openapi.Responses
   alias OpenApiSpex.{Operation, Reference}
-
 
   def get_unit_operation() do
     %Operation{
@@ -132,6 +131,7 @@ defmodule ArkeServer.Openapi.ArkeControllerSpec do
       responses: Responses.get_responses([201, 204])
     }
   end
+
   def call_arke_function_operation() do
     %Operation{
       tags: ["Group"],
@@ -150,6 +150,7 @@ defmodule ArkeServer.Openapi.ArkeControllerSpec do
       responses: Responses.get_responses([201, 204])
     }
   end
+
   def call_unit_function_operation() do
     %Operation{
       tags: ["Group"],
@@ -168,5 +169,4 @@ defmodule ArkeServer.Openapi.ArkeControllerSpec do
       responses: Responses.get_responses([201, 204])
     }
   end
-
 end

--- a/lib/arke_server/openapi/auth_controller_spec.ex
+++ b/lib/arke_server/openapi/auth_controller_spec.ex
@@ -109,5 +109,4 @@ defmodule ArkeServer.Openapi.AuthControllerSpec do
       responses: Responses.get_responses([200, 400])
     }
   end
-
 end

--- a/lib/arke_server/openapi/oauth_controller_spec.ex
+++ b/lib/arke_server/openapi/oauth_controller_spec.ex
@@ -19,6 +19,5 @@ defmodule ArkeServer.Openapi.ParameterControllerSpec do
 
   alias ArkeServer.Openapi.Responses
   alias OpenApiSpex.{Operation, Reference}
-  #todo: all api operation for parameter
-
+  # todo: all api operation for parameter
 end

--- a/lib/arke_server/openapi/parameter_controller_spec.ex
+++ b/lib/arke_server/openapi/parameter_controller_spec.ex
@@ -19,6 +19,5 @@ defmodule ArkeServer.Openapi.OAuthControllerSpec do
 
   alias ArkeServer.Openapi.Responses
   alias OpenApiSpex.{Operation, Reference}
-  #todo: all api operation for oauth
-
+  # todo: all api operation for oauth
 end

--- a/lib/arke_server/openapi/project_controller_spec.ex
+++ b/lib/arke_server/openapi/project_controller_spec.ex
@@ -20,5 +20,5 @@ defmodule ArkeServer.Openapi.ProjectControllerSpec do
   alias ArkeServer.Openapi.Responses
   alias OpenApiSpex.{Operation, Reference}
 
-  #todo: all api operation for project
+  # todo: all api operation for project
 end

--- a/lib/arke_server/openapi/spec.ex
+++ b/lib/arke_server/openapi/spec.ex
@@ -13,37 +13,37 @@
 # limitations under the License.
 
 defmodule ArkeServer.Openapi.Spec do
-
   @doc """
   For each controller define the module containing its apispec definitions.
   In your controller module:
       use ArkeServer.Openapi.Spec, module: My.Spec.Module
   """
   defmacro __using__(opts) do
-    apimodule = Keyword.get(opts,:module, nil)
-    quote do
-    alias ArkeServer.Openapi.Responses
-    alias OpenApiSpex.{Operation, Reference}
+    apimodule = Keyword.get(opts, :module, nil)
 
-    def open_api_operation(action) do
-      apimodule = unquote(apimodule)
-      unless is_nil(apimodule) do
-        func_list = get_operation_list(apimodule)
-        operation = "#{action}_operation"
-        if operation in func_list  do
-          apply(apimodule, String.to_existing_atom(operation), [])
+    quote do
+      alias ArkeServer.Openapi.Responses
+      alias OpenApiSpex.{Operation, Reference}
+
+      def open_api_operation(action) do
+        apimodule = unquote(apimodule)
+
+        unless is_nil(apimodule) do
+          func_list = get_operation_list(apimodule)
+          operation = "#{action}_operation"
+
+          if operation in func_list do
+            apply(apimodule, String.to_existing_atom(operation), [])
+          end
         end
       end
+
+      defp get_operation_list(nil), do: []
+
+      defp get_operation_list(module) do
+        module.__info__(:functions)
+        |> Enum.map(fn {func_name, _arity} -> to_string(func_name) end)
       end
-    defp get_operation_list(nil),do: []
-    defp get_operation_list(module) do
-      module.__info__(:functions) |> Enum.map(fn {func_name, _arity} -> to_string(func_name) end)
     end
-
-
   end
-
-  end
-
-
 end

--- a/lib/arke_server/openapi/struct_controller_spec.ex
+++ b/lib/arke_server/openapi/struct_controller_spec.ex
@@ -52,5 +52,4 @@ defmodule ArkeServer.Openapi.StructControllerSpec do
       responses: Responses.get_responses([201, 204])
     }
   end
-
 end

--- a/lib/arke_server/openapi/topology_controller_spec.ex
+++ b/lib/arke_server/openapi/topology_controller_spec.ex
@@ -115,5 +115,4 @@ defmodule ArkeServer.Openapi.TopologyControllerSpec do
       responses: Responses.get_responses([200])
     }
   end
-
 end

--- a/lib/arke_server/openapi/unit_controller_spec.ex
+++ b/lib/arke_server/openapi/unit_controller_spec.ex
@@ -20,7 +20,6 @@ defmodule ArkeServer.Openapi.UnitControllerSpec do
   alias ArkeServer.Openapi.Responses
   alias OpenApiSpex.{Operation, Reference}
 
-
   def search_operation() do
     %Operation{
       tags: ["Unit"],
@@ -57,5 +56,4 @@ defmodule ArkeServer.Openapi.UnitControllerSpec do
       responses: Responses.get_responses([201, 204])
     }
   end
-
 end

--- a/lib/arke_server/plugs/build_filters.ex
+++ b/lib/arke_server/plugs/build_filters.ex
@@ -50,21 +50,21 @@ defmodule ArkeServer.Plugs.BuildFilters do
         remove_match(match, acc)
       end)
       |> String.split(",")
-      |> Enum.reduce(%{error: [],operator: []},fn x,acc ->
+      |> Enum.reduce(%{error: [], operator: []}, fn x, acc ->
         case get_operator(x) do
           {:ok, op} ->
-            Map.update(acc,:operator,[],fn old ->  [op | old]end)
+            Map.update(acc, :operator, [], fn old -> [op | old] end)
 
           {:error, msg} ->
-            Map.update(acc,:error,[],fn old -> msg ++ old end)
+            Map.update(acc, :error, [], fn old -> msg ++ old end)
         end
       end)
 
+    errors = Map.get(operator_list, :error)
+    operators = Map.get(operator_list, :operator)
 
-    errors = Map.get(operator_list,:error)
-    operators =  Map.get(operator_list,:operator)
-    if length(errors) >0 do
-      {:error,errors}
+    if length(errors) > 0 do
+      {:error, errors}
     else
       filters =
         Enum.with_index(operators)

--- a/lib/arke_server/plugs/get_project.ex
+++ b/lib/arke_server/plugs/get_project.ex
@@ -14,8 +14,8 @@
 
 defmodule ArkeServer.Plugs.GetProject do
   @moduledoc """
-             Plug to get the project from the request header
-             """
+  Plug to get the project from the request header
+  """
   import Plug.Conn
   alias Arke.Utils.ErrorGenerator, as: Error
 

--- a/lib/arke_server/router.ex
+++ b/lib/arke_server/router.ex
@@ -56,7 +56,7 @@ defmodule ArkeServer.Router do
     plug(ArkeServer.Plugs.Permission)
   end
 
-  #todo: refactor router to divide permission and auth
+  # todo: refactor router to divide permission and auth
   pipeline :tmp_auth_pipe do
     plug(:accepts, ["json", "multipart"])
     plug(ArkeServer.Plugs.AuthPipeline)

--- a/lib/openapi/schemas/responses.ex
+++ b/lib/openapi/schemas/responses.ex
@@ -1,5 +1,4 @@
 defmodule ArkeServer.Openapi.Responses do
-
   alias OpenApiSpex.Operation
 
   def get_responses(exclude \\ nil)

--- a/test/arke_server/http_client_test.exs
+++ b/test/arke_server/http_client_test.exs
@@ -23,7 +23,10 @@ defmodule ArkeServer.HttpClientTest do
     for {name, value} <- vars do
       previous = System.get_env(name)
       System.put_env(name, value)
-      on_exit(fn -> if previous, do: System.put_env(name, previous), else: System.delete_env(name) end)
+
+      on_exit(fn ->
+        if previous, do: System.put_env(name, previous), else: System.delete_env(name)
+      end)
     end
   end
 
@@ -120,7 +123,12 @@ defmodule ArkeServer.HttpClientTest do
 
       Req.Test.stub(__MODULE__, fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
-        send(pid, {:request, conn.request_path, Plug.Conn.get_req_header(conn, "authorization"), body})
+
+        send(
+          pid,
+          {:request, conn.request_path, Plug.Conn.get_req_header(conn, "authorization"), body}
+        )
+
         Req.Test.json(conn, %{"id" => "notification-1"})
       end)
 

--- a/test/controllers/arke_controller_test.exs
+++ b/test/controllers/arke_controller_test.exs
@@ -194,7 +194,10 @@ defmodule ArkeServer.ArkeControllerTest do
       check_db("unit_api_post")
 
       conn =
-        post(conn, "/lib/test_arke_group_ac/unit", %{id: "unit_api_post", api_label: "Test Unit Api"})
+        post(conn, "/lib/test_arke_group_ac/unit", %{
+          id: "unit_api_post",
+          api_label: "Test Unit Api"
+        })
 
       json_body = json_response(conn, 200)
 

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -39,7 +39,11 @@ defmodule ArkeServer.AuthControllerTest do
     assert is_binary(body_resp["content"]["refresh_token"])
 
     user =
-      QueryManager.get_by(project: :arke_system, arke_id: :user, id: body_resp["content"]["arke_system_user"])
+      QueryManager.get_by(
+        project: :arke_system,
+        arke_id: :user,
+        id: body_resp["content"]["arke_system_user"]
+      )
 
     assert user.data.username == "user3"
 

--- a/test/support/create_arke.ex
+++ b/test/support/create_arke.ex
@@ -13,7 +13,10 @@ defmodule ArkeServer.Support.CreateArke do
       nullable: true
     )
 
-    parameter(:enum_string_support, :string, required: false, values: ["first", "second", "third"])
+    parameter(:enum_string_support, :string,
+      required: false,
+      values: ["first", "second", "third"]
+    )
 
     parameter(:integer_support, :integer, required: false, default_integer: 5)
 


### PR DESCRIPTION
## Description

Adds `.formatter.exs`, the mechanical format pass, and a
`mix format --check-formatted` step in CI guarded by a `lint` flag on the 1.18.4
matrix leg.

`.formatter.exs` declares `import_deps: [:phoenix]` so the formatter leaves the
router and endpoint DSL paren-less as written.

## Docs
- [ ] I have updated the docs accordingly

## Test

- [ ] I have added tests that prove my fix is effective or that my feature works
