### PR TITLE
fix: return identical response for unknown emails on password recovery

### DIFF
--- a/lib/arke_server/controllers/auth_controller.ex
+++ b/lib/arke_server/controllers/auth_controller.ex
@@ -597,8 +597,7 @@ defmodule ArkeServer.AuthController do
 
     case QueryManager.get_by(project: project, group_id: :arke_auth_member, email: email) do
       nil ->
-        {:error, msg} = Error.create(:auth, "member not found with given email")
-        ResponseManager.send_resp(conn, 404, msg)
+        handle_recover_password_mode(conn, params, nil, auth_mode)
 
       member ->
         case member.arke_id do
@@ -669,6 +668,15 @@ defmodule ArkeServer.AuthController do
       "otp_mail"
     )
   end
+
+  defp handle_recover_password_mode(
+         conn,
+         %{"email" => _email, "otp" => otp},
+         nil,
+         "otp_mail"
+       )
+       when is_nil(otp),
+       do: ResponseManager.send_resp(conn, 200, %{content: "OTP send successfully"})
 
   defp handle_recover_password_mode(conn, _, _, "otp_mail"),
     do: params_required(conn, ["email", "otp"])
@@ -805,6 +813,14 @@ defmodule ArkeServer.AuthController do
         end
     end
   end
+
+  defp handle_reset_password_mode(
+         conn,
+         %{"new_password" => _new_password, "otp" => _otp},
+         nil,
+         "otp_mail"
+       ),
+       do: ResponseManager.send_resp(conn, 401, nil, "Unauthorized")
 
   defp get_project(project) when is_nil(project), do: :arke_system
   defp get_project(project), do: project

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -151,11 +151,63 @@ defmodule ArkeServer.AuthControllerTest do
   end
 
   describe "POST /lib/auth/recover_password" do
+    setup [:create_user_setup]
+
     # The super_admin branch needs a member arke carrying an `email` parameter, which
     # neither super_admin nor member_public declares, so only the miss is reachable here.
-    test "answers 404 when no member carries the email", %{conn: conn} do
-      post(conn, "/lib/auth/recover_password", email: "nobody@arke.test")
-      |> json_response(404)
+    test "answers the same body whether or not the email is known", %{conn: conn} do
+      known =
+        post(conn, "/lib/auth/recover_password", email: "user2@arke.test")
+        |> json_response(200)
+
+      unknown =
+        build_conn()
+        |> Plug.Conn.put_req_header("arke-project-key", "test_schema")
+        |> post("/lib/auth/recover_password", email: "nobody@arke.test")
+        |> json_response(200)
+
+      # Check if we got the same response for both
+      assert known == unknown
+      assert known["content"] == "An email has been sent to the given email"
+
+      # The known email still went through the real flow
+      # so we check if a reset_password_token was created
+      user = QueryManager.get_by(project: :arke_system, username: "user2")
+
+      assert QueryManager.filter_by(
+               project: :arke_system,
+               arke_id: :reset_password_token,
+               user_id: to_string(user.id)
+             ) != []
+
+      delete_user("user2")
+    end
+  end
+
+  describe "password recovery in otp_mail mode" do
+    setup do
+      System.put_env("AUTH_MODE", "otp_mail")
+      on_exit(fn -> System.delete_env("AUTH_MODE") end)
+      :ok
+    end
+
+    test "recover_password reports the OTP as sent when no member carries the email", %{
+      conn: conn
+    } do
+      body =
+        post(conn, "/lib/auth/recover_password", email: "nobody@arke.test", otp: nil)
+        |> json_response(200)
+
+      assert body["content"] == "OTP send successfully"
+    end
+
+    test "reset_password answers 401 when no member carries the email", %{conn: conn} do
+      post(conn, "/lib/auth/reset_password",
+        email: "nobody@arke.test",
+        new_password: "password",
+        otp: "000000"
+      )
+      |> json_response(401)
     end
   end
 


### PR DESCRIPTION
## Description

`recover_password` returned `404 "member not found with given email"` for
unknown addresses and 200 for registered ones, so the endpoint could be
used to enumerate accounts.
Unknown emails now go through the same mode
handler and get the identical 200 response.

`reset_password` same thing: an unknown email passed nil as member,
matched no otp_mail clause and raised `FunctionClauseError (500)` instead
of the 401 a wrong otp returns.
